### PR TITLE
fix(sdl): safe property access on PATCH response for system tables

### DIFF
--- a/MicrosoftSentinel/PowerShell/SDL/Set-SentinelTableRetention.ps1
+++ b/MicrosoftSentinel/PowerShell/SDL/Set-SentinelTableRetention.ps1
@@ -460,7 +460,12 @@ function Get-AllWorkspaceTables {
 function Get-TableCurrentState {
     param ([string]$TableName, [string]$BaseUri, [string]$Token, [int]$Retries)
     $uri = "$BaseUri/tables/${TableName}?api-version=2025-07-01"
-    try   { return (Invoke-LAApi -Uri $uri -Method 'GET' -Token $Token -Retries $Retries).properties }
+    try {
+        $response = Invoke-LAApi -Uri $uri -Method 'GET' -Token $Token -Retries $Retries
+        if ($response -and $response.PSObject.Properties['properties']) { return $response.properties }
+        Write-Warning "  GET response for '$TableName' has no 'properties' envelope — PATCH may also lack it"
+        return $null
+    }
     catch { Write-Warning "  Could not retrieve state for '$TableName': $_"; return $null }
 }
 
@@ -861,11 +866,16 @@ if ($AllTables) {
     $allTableObjects = Get-AllWorkspaceTables -BaseUri $baseUri -Token $token -Retries $MaxRetries
 
     if ($FilterPlan) {
-        $allTableObjects = @($allTableObjects | Where-Object { $_.properties.plan -in $FilterPlan })
+        $allTableObjects = @($allTableObjects | Where-Object {
+            $_.PSObject.Properties['properties'] -and $_.properties.PSObject.Properties['plan'] -and $_.properties.plan -in $FilterPlan
+        })
         Write-Host "  After plan filter    : $($allTableObjects.Count) tables"
     }
     if ($FilterTableType) {
-        $allTableObjects = @($allTableObjects | Where-Object { $_.properties.schema.tableType -in $FilterTableType })
+        $allTableObjects = @($allTableObjects | Where-Object {
+            $_.PSObject.Properties['properties'] -and $_.properties.PSObject.Properties['schema'] -and
+            $_.properties.schema.PSObject.Properties['tableType'] -and $_.properties.schema.tableType -in $FilterTableType
+        })
         Write-Host "  After type filter    : $($allTableObjects.Count) tables"
     }
     if ($SkipEmpty) {
@@ -919,7 +929,7 @@ foreach ($tableName in $resolvedTableNames) {
     # Reuse list-response properties when AllTables (saves API calls at scale)
     if ($allTableObjects) {
         $cachedObj = $allTableObjects | Where-Object { $_.name -eq $tableName } | Select-Object -First 1
-        $current   = $cachedObj ? $cachedObj.properties : $null
+        $current   = ($cachedObj -and $cachedObj.PSObject.Properties['properties']) ? $cachedObj.properties : $null
     } else {
         $current = Get-TableCurrentState -TableName $tableName -BaseUri $baseUri -Token $token -Retries $MaxRetries
     }

--- a/MicrosoftSentinel/PowerShell/SDL/Set-SentinelTableRetention.ps1
+++ b/MicrosoftSentinel/PowerShell/SDL/Set-SentinelTableRetention.ps1
@@ -1038,7 +1038,8 @@ foreach ($tableName in $resolvedTableNames) {
     try {
         Write-Host "`n  Applying '$tableName'..." -NoNewline
         $response  = Invoke-LAApi -Uri $patchUri -Method 'PATCH' -Token $token -Body $body -Retries $MaxRetries
-        $provState = $response.properties.provisioningState
+        $respProps = ($response -and $response.PSObject.Properties['properties']) ? $response.properties : $null
+        $provState = ($respProps -and $respProps.PSObject.Properties['provisioningState']) ? $respProps.provisioningState : 'Unknown'
 
         $statusMsg = ($provState -eq 'Succeeded') ? 'Success' : "Pending - $provState"
         $msgColor  = ($provState -eq 'Succeeded') ? 'Green'   : 'Yellow'
@@ -1049,15 +1050,19 @@ foreach ($tableName in $resolvedTableNames) {
             Write-Host "    Re-run with -DryRun to verify the final state once provisioning completes." -ForegroundColor DarkYellow
         }
 
+        $respHot   = ($respProps -and $respProps.PSObject.Properties['retentionInDays'])      ? $respProps.retentionInDays      : $propHot
+        $respTotal = ($respProps -and $respProps.PSObject.Properties['totalRetentionInDays'])  ? $respProps.totalRetentionInDays  : $propTotal
+        $respLake  = ($respProps -and $respProps.PSObject.Properties['archiveRetentionInDays'])? $respProps.archiveRetentionInDays : $propLake
+
         $results.Add([PSCustomObject]@{
             Table         = $tableName
             Plan          = $curPlan
             TableType     = $curType
             CurrentHot    = $curHot
             CurrentTotal  = $curTotal
-            ProposedHot   = $response.properties.retentionInDays
-            ProposedTotal = $response.properties.totalRetentionInDays
-            LakeDays      = $response.properties.archiveRetentionInDays
+            ProposedHot   = $respHot
+            ProposedTotal = $respTotal
+            LakeDays      = $respLake
             Status        = $statusMsg
         })
         $changeCount++


### PR DESCRIPTION
## Summary
- Fix `Set-SentinelTableRetention.ps1` failing on tables where the PATCH response lacks a `properties` wrapper (e.g. `SentinelAudit`, `AADUserRiskEvents`, and other system/read-only tables)
- With `Set-StrictMode -Version Latest`, accessing `$response.properties` on these responses threw a terminating error
- Uses safe `PSObject.Properties[]` checks consistent with the existing pattern elsewhere in the script, falling back to pre-computed proposed values when the response lacks properties

## Test plan
- [ ] Run against a workspace and confirm no errors on system tables (e.g. `SentinelAudit`, `AADUserRiskEvents`)
- [ ] Verify standard tables (e.g. `SecurityEvent`) still report correct proposed values from the API response
- [ ] Run with `-AllTables` to confirm all tables are processed without errors
- [ ] Run with `-DryRun` to confirm no regression in dry-run output